### PR TITLE
fix: responses with no content, like 204 No Content, should not try to decode empty content to json

### DIFF
--- a/requests_openapi_client/core.py
+++ b/requests_openapi_client/core.py
@@ -221,7 +221,7 @@ class Operation(object):
                 raise e
 
             data = (
-                response.json() if int(response.headers["Content-Length"]) > 0 else None
+                response.json() if response.content and len(response.content) > 0 else None
             )
             if response.status_code in self._response_types:
                 return deserialize_as(data, self._response_types[response.status_code])

--- a/requests_openapi_client/core.py
+++ b/requests_openapi_client/core.py
@@ -220,7 +220,9 @@ class Operation(object):
                     pass
                 raise e
 
-            data = response.json()
+            data = (
+                response.json() if int(response.headers["Content-Length"]) > 0 else None
+            )
             if response.status_code in self._response_types:
                 return deserialize_as(data, self._response_types[response.status_code])
             elif "default" in self._response_types:


### PR DESCRIPTION
The idea here would be that we only call the conversion to json if there is content length, otherwise just use `None`.

I did confirm that if the swagger definition does not contain a "content" type for a response, it will not be present in self._response_types. Ex: 
```
"responses": {
    "204": {
        "description": "No guidance data found for given parameters"
    }
}
```

Therefore, if the immediately-following `if` case, we will fall into the `else` case and return `None`, which seems reasonable.

Technically, we probably only want to get the`.json` if the content type is also application/json, but not sure if that's worth checking for for our use cases.

If you have any test case ideas or things I should validate on top of this - please let me know.