### PR TITLE
Fix crasher on duplicate operation IDs

### DIFF
--- a/requests_openapi_client/core.py
+++ b/requests_openapi_client/core.py
@@ -369,10 +369,10 @@ class BaseClient:
                     log.warning(
                         f"multiple '{operation_id}' found , operation ID should be unique"
                     )
-                    v = self._operations[operation_id]
+                    v = cls._operations[operation_id]
                     if type(v) is not list:
-                        self._operations[operation_id] = [v]
-                    self._operations[operation_id].append(op)
+                        cls._operations[operation_id] = [v]
+                    cls._operations[operation_id].append(op)
 
                 tags = op_spec.get(OpenAPIKeyWord.TAGS, None)
                 if tags:


### PR DESCRIPTION
OpenAPI `operationId` fields are [supposed to be unique](https://swagger.io/docs/specification/paths-and-operations/#:~:text=operationid%20is%20an%20optional%20unique%20string%20used%20to%20identify%20an%20operation.%20if%20provided%2C%20these%20ids%20must%20be%20unique%20among%20all%20operations%20described%20in%20your%20api.). If a duplicate is found, the intent in this library is to log a warning, but instantiate the client anyway, using the last-defined one with a given name as canonical. Unfortunately, due to sloppy refactoring on my part, we instead throw an exception (we just hadn't ever noticed because this particular issue hadn't ever occurred in our production use).

This PR makes things work as intended.