### PR TITLE
Make sure snake-case names are legal python identifiers

### DIFF
--- a/requests_openapi_client/util.py
+++ b/requests_openapi_client/util.py
@@ -1,3 +1,4 @@
+import keyword
 import re
 
 CAMEL_NAME_RE = re.compile('(.)([A-Z][a-z]+)')
@@ -7,4 +8,7 @@ def camel_to_snake(name):
     name = name.replace(' ', '_')
     name = CAMEL_NAME_RE.sub(r'\1_\2', name)
     name = CAMEL_RE.sub(r'\1_\2', name).lower().replace("-", "_")
-    return MULTI_UNDER_RE.sub('_', name)
+    name = MULTI_UNDER_RE.sub('_', name)
+    if keyword.iskeyword(name):
+        name = f"{name}_"
+    return name


### PR DESCRIPTION
We encountered a situation where an openapi specification we wanted to consume described an endpoint that accepted a parameter called `global`, which resulted in the generation of a function with a `global` function parameter, which was causing a syntax error because `global` is a reserved word. This PR avoids that syntax error.

There's a utility function `camel_to_snake`, which is maybe a bit misnamed -- it does, indeed, convert from camel case to snake case, but more generally takes the name of an identifier in an OpenAPI spec and makes it Python-friendly (converts camel case to snake case, removes hyphens, collapses multiple underscores, etc.). This PR adds one more check to that process to detect reserved words and, if found, add underscores to the end (so `global` becomes `global_`). We store mapping elsewhere from these Python-friendly names to the originals, so there's no need for this to be reversible, etc.