### PR TITLE
add use_python_names to deserialize

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,22 @@
+name: run tests for requests-openapi-client
+run-name: "test run: ${{github.ref_name}} ${{ github.event.head_commit.message }}"
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+     
+      - name: Install dependencies
+        run: python -m pip install -r requirements.txt
+      # TODO: will work up to this
+      # - name: Lint with ruff
+      #   uses: chartboost/ruff-action@v1
+      - name: Run test
+        run: pytest

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -14,7 +14,7 @@ jobs:
           python-version: "3.12"
      
       - name: Install dependencies
-        run: python -m pip install -r requirements.txt
+        run: python -m pip install -e ".[dev]"
       # TODO: will work up to this
       # - name: Lint with ruff
       #   uses: chartboost/ruff-action@v1

--- a/requests_openapi_client/schemas.py
+++ b/requests_openapi_client/schemas.py
@@ -37,8 +37,8 @@ class BaseDto:
     def deserialize(cls, data, use_python_names=False):
         init_fields = {}
         for field_name, field in cls.__dataclass_fields__.items():
-            # If use_python_names=True, the data keys are snake_case (same as field_name)
-            # If use_python_names=False, the data keys are camelCase (from name_map)
+            # If use_python_names=True, the data keys are the same as field_name
+            # If use_python_names=False, the data keys are from name_map
             raw_name = field_name if use_python_names else cls.name_map[field_name]
             if raw_name in data:
                 init_fields[field_name] = deserialize_as(data[raw_name], field.type, use_python_names=use_python_names)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,115 @@
+import datetime
+import pytest
+import dataclasses
+from requests_openapi_client.schemas import (
+    BaseDto,
+    deserialize_as,
+    serialize_as,
+    type_for_schema,
+    TaggedUnion,
+)
+
+
+@dataclasses.dataclass
+class ExampleDto(BaseDto):
+    field1: int
+    field2: str = "default"
+
+
+def test_base_dto_serialize():
+    dto = ExampleDto(field1=123)
+    dto.name_map = {"field1": "Field1", "field2": "Field2"}
+    serialized = dto.serialize()
+    assert serialized == {"Field1": 123, "Field2": "default"}
+
+
+def test_base_dto_serialize_use_python_names():
+    dto = ExampleDto(field1=123)
+    dto.name_map = {"field1": "Field1", "field2": "Field2"}
+    serialized = dto.serialize(use_python_names=True)
+    assert serialized == {"field1": 123, "field2": "default"}
+
+
+def test_base_dto_serialize_use_python_names_no_map():
+    dto = ExampleDto(field1=123, field2="hello")
+    dto.name_map = {"field1": "Field1", "Field2": "Field2"}
+    serialized = dto.serialize(use_python_names=True)
+    assert serialized == {"field1": 123, "field2": "hello"}
+
+    with pytest.raises(Exception):
+        # no use_python_names but no mapping for lowercase `field2`
+        serialized = dto.serialize()
+
+
+def test_base_dto_deserialize():
+    ExampleDto.name_map = {"field1": "Field1", "field2": "Field2"}
+    data = {"Field1": 123, "Field2": "test"}
+    dto = ExampleDto.deserialize(data)
+    assert dto.field1 == 123
+    assert dto.field2 == "test"
+
+
+def test_base_dto_deserialize_use_python_names():
+    ExampleDto.name_map = {"field1": "Field1", "field2": "Field2"}
+
+    data = {"field1": 123, "field2": "test"}
+    dto = ExampleDto.deserialize(data, use_python_names=True)
+    assert dto.field1 == 123
+    assert dto.field2 == "test"
+
+    # there are no "python names" in this data
+    data = {"Field1": 123, "Field2": "test"}
+    dto = ExampleDto.deserialize(data, use_python_names=True)
+    assert dto.field1 == dataclasses.MISSING
+    assert dto.field2 == "default"
+
+
+def test_deserialize_as():
+    data = "2023-01-01T00:00:00Z"
+    result = deserialize_as(data, datetime.datetime)
+    # TODO: should action this preserve the timezone? It doesn't currently
+    assert result.replace(tzinfo=None) == datetime.datetime(2023, 1, 1, 0, 0, 0)
+
+
+def test_serialize_as():
+    data = datetime.datetime(2023, 1, 1, 0, 0, 0)
+    result = serialize_as(data, datetime.datetime)
+    assert result == "2023-01-01T00:00:00"
+
+
+def test_serialize_as_tz():
+    data = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+    result = serialize_as(data, datetime.datetime)
+    assert result == "2023-01-01T00:00:00Z"
+
+
+def test_type_for_schema():
+    schema = {"type": "string", "format": "date-time"}
+    result = type_for_schema(schema, {})
+    assert result == datetime.datetime
+
+
+def test_tagged_union_deserialize():
+    @dataclasses.dataclass
+    class A(BaseDto):
+        pass
+
+    @dataclasses.dataclass
+    class B(BaseDto):
+        pass
+
+    union = TaggedUnion(
+        type_options=[
+            {"$ref": "#/components/schemas/A"},
+            {"$ref": "#/components/schemas/B"},
+        ],
+        discriminator={
+            "propertyName": "type",
+            "mapping": {"a": "#/components/schemas/A", "b": "#/components/schemas/B"},
+        },
+        full_spec={},
+        realized_types={"A": A, "B": B},
+    )
+    data = {"type": "a"}
+    result = union.deserialize(data)
+    assert isinstance(result, A)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,6 +1,7 @@
 import datetime
 import pytest
 import dataclasses
+from typing import List
 from requests_openapi_client.schemas import (
     BaseDto,
     deserialize_as,
@@ -16,71 +17,150 @@ class ExampleDto(BaseDto):
     field2: str = "default"
 
 
-def test_base_dto_serialize():
-    dto = ExampleDto(field1=123)
-    dto.name_map = {"field1": "Field1", "field2": "Field2"}
-    serialized = dto.serialize()
-    assert serialized == {"Field1": 123, "Field2": "default"}
+@dataclasses.dataclass
+class ChildDto(BaseDto):
+    value: int
+    label: str = "child"
 
 
-def test_base_dto_serialize_use_python_names():
-    dto = ExampleDto(field1=123)
-    dto.name_map = {"field1": "Field1", "field2": "Field2"}
-    serialized = dto.serialize(use_python_names=True)
-    assert serialized == {"field1": 123, "field2": "default"}
+@dataclasses.dataclass
+class ParentDto(BaseDto):
+    name: str
+    child: ChildDto = None
 
 
-def test_base_dto_serialize_use_python_names_no_map():
-    dto = ExampleDto(field1=123, field2="hello")
-    dto.name_map = {"field1": "Field1", "Field2": "Field2"}
-    serialized = dto.serialize(use_python_names=True)
-    assert serialized == {"field1": 123, "field2": "hello"}
-
-    with pytest.raises(Exception):
-        # no use_python_names but no mapping for lowercase `field2`
+class TestSerialize:
+    def test_base_dto_serialize(self):
+        dto = ExampleDto(field1=123)
+        dto.name_map = {"field1": "Field1", "field2": "Field2"}
         serialized = dto.serialize()
+        assert serialized == {"Field1": 123, "Field2": "default"}
+
+    def test_base_dto_serialize_use_python_names(self):
+        dto = ExampleDto(field1=123)
+        dto.name_map = {"field1": "Field1", "field2": "Field2"}
+        serialized = dto.serialize(use_python_names=True)
+        assert serialized == {"field1": 123, "field2": "default"}
+
+    def test_base_dto_serialize_use_python_names_no_map(self):
+        dto = ExampleDto(field1=123, field2="hello")
+        dto.name_map = {"field1": "Field1", "Field2": "Field2"}
+        serialized = dto.serialize(use_python_names=True)
+        assert serialized == {"field1": 123, "field2": "hello"}
+
+        with pytest.raises(Exception):
+            # no use_python_names but no mapping for lowercase `field2`
+            serialized = dto.serialize()
 
 
-def test_base_dto_deserialize():
-    ExampleDto.name_map = {"field1": "Field1", "field2": "Field2"}
-    data = {"Field1": 123, "Field2": "test"}
-    dto = ExampleDto.deserialize(data)
-    assert dto.field1 == 123
-    assert dto.field2 == "test"
+class TestSerializeAs:
+    def test_serialize_as(self):
+        data = datetime.datetime(2023, 1, 1, 0, 0, 0)
+        result = serialize_as(data, datetime.datetime)
+        assert result == "2023-01-01T00:00:00"
+
+    def test_serialize_as_tz(self):
+        data = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
+        result = serialize_as(data, datetime.datetime)
+        assert result == "2023-01-01T00:00:00Z"
+
+    def test_serialize_as_list(self):
+        data = [1, 2, 3]
+        result = serialize_as(data, List[int])
+        assert result == [1, 2, 3]
+
+    def test_serialize_as_list_of_dtos(self):
+        ChildDto.name_map = {"value": "Value", "label": "Label"}
+
+        data = [
+            ChildDto(value=1, label="first"),
+            ChildDto(value=2, label="second"),
+        ]
+        result = serialize_as(data, List[ChildDto])
+
+        assert result == [
+            {"Value": 1, "Label": "first"},
+            {"Value": 2, "Label": "second"},
+        ]
+
+    def test_serialize_as_list_of_dtos_use_python_names(self):
+        ChildDto.name_map = {"value": "Value", "label": "Label"}
+
+        data = [
+            ChildDto(value=1, label="first"),
+            ChildDto(value=2, label="second"),
+        ]
+        result = serialize_as(data, List[ChildDto], use_python_names=True)
+
+        assert result == [
+            {"value": 1, "label": "first"},
+            {"value": 2, "label": "second"},
+        ]
 
 
-def test_base_dto_deserialize_use_python_names():
-    ExampleDto.name_map = {"field1": "Field1", "field2": "Field2"}
+class TestDeserialize:
+    def test_base_dto_deserialize(self):
+        ExampleDto.name_map = {"field1": "Field1", "field2": "Field2"}
+        data = {"Field1": 123, "Field2": "test"}
+        dto = ExampleDto.deserialize(data)
+        assert dto.field1 == 123
+        assert dto.field2 == "test"
 
-    data = {"field1": 123, "field2": "test"}
-    dto = ExampleDto.deserialize(data, use_python_names=True)
-    assert dto.field1 == 123
-    assert dto.field2 == "test"
+    def test_base_dto_deserialize_use_python_names(self):
+        ExampleDto.name_map = {"field1": "Field1", "field2": "Field2"}
 
-    # there are no "python names" in this data
-    data = {"Field1": 123, "Field2": "test"}
-    dto = ExampleDto.deserialize(data, use_python_names=True)
-    assert dto.field1 == dataclasses.MISSING
-    assert dto.field2 == "default"
+        data = {"field1": 123, "field2": "test"}
+        dto = ExampleDto.deserialize(data, use_python_names=True)
+        assert dto.field1 == 123
+        assert dto.field2 == "test"
 
-
-def test_deserialize_as():
-    data = "2023-01-01T00:00:00Z"
-    result = deserialize_as(data, datetime.datetime)
-    # TODO: should action this preserve the timezone? It doesn't currently
-    assert result.replace(tzinfo=None) == datetime.datetime(2023, 1, 1, 0, 0, 0)
-
-
-def test_serialize_as():
-    data = datetime.datetime(2023, 1, 1, 0, 0, 0)
-    result = serialize_as(data, datetime.datetime)
-    assert result == "2023-01-01T00:00:00"
+        # there are no "python names" in this data
+        data = {"Field1": 123, "Field2": "test"}
+        dto = ExampleDto.deserialize(data, use_python_names=True)
+        assert dto.field1 == dataclasses.MISSING
+        assert dto.field2 == "default"
 
 
-def test_serialize_as_tz():
-    data = datetime.datetime(2023, 1, 1, 0, 0, 0, tzinfo=datetime.timezone.utc)
-    result = serialize_as(data, datetime.datetime)
-    assert result == "2023-01-01T00:00:00Z"
+class TestDeserializeAs:
+    def test_deserialize_as(self):
+        data = "2023-01-01T00:00:00Z"
+        result = deserialize_as(data, datetime.datetime)
+        # TODO: should action this preserve the timezone? It doesn't currently
+        assert result.replace(tzinfo=None) == datetime.datetime(2023, 1, 1, 0, 0, 0)
+
+    def test_deserialize_as_list(self):
+        data = [1, 2, 3]
+        result = deserialize_as(data, List[int])
+        assert result == [1, 2, 3]
+
+    def test_deserialize_as_list_of_dtos(self):
+        ChildDto.name_map = {"value": "Value", "label": "Label"}
+
+        data = [
+            {"Value": 1, "Label": "first"},
+            {"Value": 2, "Label": "second"},
+        ]
+        result = deserialize_as(data, List[ChildDto])
+
+        assert len(result) == 2
+        assert all(isinstance(item, ChildDto) for item in result)
+        assert result[0].value == 1
+        assert result[0].label == "first"
+        assert result[1].value == 2
+        assert result[1].label == "second"
+
+    def test_deserialize_as_list_of_dtos_use_python_names(self):
+        ChildDto.name_map = {"value": "Value", "label": "Label"}
+
+        data = [
+            {"value": 1, "label": "first"},
+            {"value": 2, "label": "second"},
+        ]
+        result = deserialize_as(data, List[ChildDto], use_python_names=True)
+
+        assert len(result) == 2
+        assert result[0].value == 1
+        assert result[1].label == "second"
 
 
 def test_type_for_schema():
@@ -113,3 +193,63 @@ def test_tagged_union_deserialize():
     data = {"type": "a"}
     result = union.deserialize(data)
     assert isinstance(result, A)
+
+
+# --- TODO: Tests to implement ---
+
+todo = pytest.mark.skip(reason="TODO")
+
+
+@todo
+def test_type_for_schema_ref():
+    pass
+
+
+@todo
+def test_type_for_schema_allof():
+    pass
+
+
+@todo
+def test_type_for_schema_oneof():
+    pass
+
+
+@todo
+def test_type_for_schema_array():
+    pass
+
+
+@todo
+def test_serialize_required_nullable_fields():
+    pass
+
+
+@todo
+def test_deserialize_default_factory():
+    pass
+
+
+@todo
+def test_tagged_union_serialize():
+    pass
+
+
+@todo
+def test_tagged_union_errors():
+    pass
+
+
+@todo
+def test_format_schema_name():
+    pass
+
+
+@todo
+def test_update_field_type():
+    pass
+
+
+@todo
+def test_add_types_to_module():
+    pass

--- a/tests/test_todo.py
+++ b/tests/test_todo.py
@@ -1,2 +1,0 @@
-def test_pass():
-    assert True


### PR DESCRIPTION
1. support python names in deserialize -- basically allows deserializing something previously serialized with `use_python_names=True`
3. add tests
4. add a test runner