### PR TITLE
all deserialize methods should have `use_python_names` arg

### DIFF
--- a/requests_openapi_client/schemas.py
+++ b/requests_openapi_client/schemas.py
@@ -143,13 +143,13 @@ class TaggedUnion:
     def type_for_annotation(self):
         return typing.Union.__getitem__(tuple(self.allowed_types))
 
-    def deserialize(self, data):
+    def deserialize(self, data, use_python_names=False):
         type_value = data.get(self.discriminator_field, None)
         if not type_value:
             raise Exception("discriminator mapping field not found on union object")
         if type_value not in self.discriminator_mapping:
             raise Exception(f"discriminator value {type_value} not in union")
-        return deserialize_as(data, self.discriminator_mapping[type_value])
+        return deserialize_as(data, self.discriminator_mapping[type_value], use_python_names=use_python_names)
 
 def update_field_type(model, field_name, new_type):
     model.__dataclass_fields__[field_name].type = new_type

--- a/requests_openapi_client/schemas.py
+++ b/requests_openapi_client/schemas.py
@@ -143,8 +143,22 @@ class TaggedUnion:
     def type_for_annotation(self):
         return typing.Union.__getitem__(tuple(self.allowed_types))
 
+    def _get_discriminator_field_name(self, use_python_names):
+        """Get the discriminator field name, using reverse_name_map from member types if available."""
+        if not use_python_names:
+            return self.discriminator_field
+
+        # Look up the python name from any of the member types' reverse_name_map
+        for member_type in self.allowed_types:
+            if hasattr(member_type, 'reverse_name_map') and self.discriminator_field in member_type.reverse_name_map:
+                return member_type.reverse_name_map[self.discriminator_field]
+
+        # Fallback to camel_to_snake if no mapping found
+        return camel_to_snake(self.discriminator_field)
+
     def deserialize(self, data, use_python_names=False):
-        type_value = data.get(self.discriminator_field, None)
+        field_name = self._get_discriminator_field_name(use_python_names)
+        type_value = data.get(field_name, None)
         if not type_value:
             raise Exception("discriminator mapping field not found on union object")
         if type_value not in self.discriminator_mapping:

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -163,77 +163,223 @@ class TestDeserializeAs:
         assert result[1].label == "second"
 
 
+class TestTaggedUnion:
+    def test_tagged_union_deserialize(self):
+        @dataclasses.dataclass
+        class A(BaseDto):
+            pass
+
+        @dataclasses.dataclass
+        class B(BaseDto):
+            pass
+
+        union = TaggedUnion(
+            type_options=[
+                {"$ref": "#/components/schemas/A"},
+                {"$ref": "#/components/schemas/B"},
+            ],
+            discriminator={
+                "propertyName": "type",
+                "mapping": {
+                    "a": "#/components/schemas/A",
+                    "b": "#/components/schemas/B",
+                },
+            },
+            full_spec={},
+            realized_types={"A": A, "B": B},
+        )
+        data = {"type": "a"}
+        result = union.deserialize(data)
+        assert isinstance(result, A)
+
+    def test_tagged_union_deserialize_use_python_names(self):
+        @dataclasses.dataclass
+        class A(BaseDto):
+            value: int
+            label: str = "default"
+
+        @dataclasses.dataclass
+        class B(BaseDto):
+            pass
+
+        A.name_map = {"value": "Value", "label": "Label"}
+        B.name_map = {}
+
+        union = TaggedUnion(
+            type_options=[
+                {"$ref": "#/components/schemas/A"},
+                {"$ref": "#/components/schemas/B"},
+            ],
+            discriminator={
+                "propertyName": "type",
+                "mapping": {
+                    "a": "#/components/schemas/A",
+                    "b": "#/components/schemas/B",
+                },
+            },
+            full_spec={},
+            realized_types={"A": A, "B": B},
+        )
+
+        # With use_python_names=True, keys should be lowercase
+        data = {"type": "a", "value": 42, "label": "test"}
+        result = union.deserialize(data, use_python_names=True)
+        assert isinstance(result, A)
+        assert result.value == 42
+        assert result.label == "test"
+
+        # Without use_python_names, keys should be uppercase
+        data = {"type": "a", "Value": 42, "Label": "test"}
+        result = union.deserialize(data, use_python_names=False)
+        assert isinstance(result, A)
+        assert result.value == 42
+        assert result.label == "test"
+
+    def test_tagged_union_deserialize_camel_case_discriminator(self):
+        @dataclasses.dataclass
+        class SchemeA(BaseDto):
+            pass
+
+        @dataclasses.dataclass
+        class SchemeB(BaseDto):
+            pass
+
+        SchemeA.name_map = {"big_scheme": "BigScheme"}
+        SchemeA.reverse_name_map = {"BigScheme": "big_scheme"}
+        SchemeB.name_map = {"big_scheme": "BigScheme"}
+        SchemeB.reverse_name_map = {"BigScheme": "big_scheme"}
+
+        union = TaggedUnion(
+            type_options=[
+                {"$ref": "#/components/schemas/SchemeA"},
+                {"$ref": "#/components/schemas/SchemeB"},
+            ],
+            discriminator={
+                "propertyName": "BigScheme",  # camelCase
+                "mapping": {
+                    "a": "#/components/schemas/SchemeA",
+                    "b": "#/components/schemas/SchemeB",
+                },
+            },
+            full_spec={},
+            realized_types={"SchemeA": SchemeA, "SchemeB": SchemeB},
+        )
+
+        # With use_python_names=True, discriminator field should use reverse_name_map
+        data = {"big_scheme": "a"}
+        result = union.deserialize(data, use_python_names=True)
+        assert isinstance(result, SchemeA)
+
+        # Without use_python_names, discriminator field should be camelCase
+        data = {"BigScheme": "b"}
+        result = union.deserialize(data, use_python_names=False)
+        assert isinstance(result, SchemeB)
+
+    def test_tagged_union_missing_property_name(self):
+        @dataclasses.dataclass
+        class A(BaseDto):
+            pass
+
+        with pytest.raises(
+            Exception, match="discriminator property name and mapping are required"
+        ):
+            TaggedUnion(
+                type_options=[{"$ref": "#/components/schemas/A"}],
+                discriminator={
+                    # missing propertyName
+                    "mapping": {"a": "#/components/schemas/A"},
+                },
+                full_spec={},
+                realized_types={"A": A},
+            )
+
+    def test_tagged_union_missing_mapping(self):
+        @dataclasses.dataclass
+        class A(BaseDto):
+            pass
+
+        with pytest.raises(
+            Exception, match="discriminator property name and mapping are required"
+        ):
+            TaggedUnion(
+                type_options=[{"$ref": "#/components/schemas/A"}],
+                discriminator={
+                    "propertyName": "type",
+                    # missing mapping
+                },
+                full_spec={},
+                realized_types={"A": A},
+            )
+
+    def test_tagged_union_discriminator_field_not_in_data(self):
+        @dataclasses.dataclass
+        class A(BaseDto):
+            pass
+
+        A.name_map = {}
+
+        union = TaggedUnion(
+            type_options=[{"$ref": "#/components/schemas/A"}],
+            discriminator={
+                "propertyName": "type",
+                "mapping": {"a": "#/components/schemas/A"},
+            },
+            full_spec={},
+            realized_types={"A": A},
+        )
+
+        with pytest.raises(Exception, match="discriminator mapping field not found"):
+            union.deserialize({"other_field": "value"})
+
+    def test_tagged_union_invalid_discriminator_value(self):
+        @dataclasses.dataclass
+        class A(BaseDto):
+            pass
+
+        A.name_map = {}
+
+        union = TaggedUnion(
+            type_options=[{"$ref": "#/components/schemas/A"}],
+            discriminator={
+                "propertyName": "type",
+                "mapping": {"a": "#/components/schemas/A"},
+            },
+            full_spec={},
+            realized_types={"A": A},
+        )
+
+        with pytest.raises(Exception, match="discriminator value .* not in union"):
+            union.deserialize({"type": "invalid_value"})
+
+    def test_tagged_union_fallback_to_camel_to_snake(self):
+        @dataclasses.dataclass
+        class A(BaseDto):
+            pass
+
+        # No reverse_name_map set
+        A.name_map = {}
+        A.reverse_name_map = {}
+
+        union = TaggedUnion(
+            type_options=[{"$ref": "#/components/schemas/A"}],
+            discriminator={
+                "propertyName": "someDiscriminatorField",  # camelCase
+                "mapping": {"a": "#/components/schemas/A"},
+            },
+            full_spec={},
+            realized_types={"A": A},
+        )
+
+        # Should fall back to camel_to_snake conversion
+        data = {"some_discriminator_field": "a"}
+        result = union.deserialize(data, use_python_names=True)
+        assert isinstance(result, A)
+
+
 def test_type_for_schema():
     schema = {"type": "string", "format": "date-time"}
     result = type_for_schema(schema, {})
     assert result == datetime.datetime
-
-
-def test_tagged_union_deserialize():
-    @dataclasses.dataclass
-    class A(BaseDto):
-        pass
-
-    @dataclasses.dataclass
-    class B(BaseDto):
-        pass
-
-    union = TaggedUnion(
-        type_options=[
-            {"$ref": "#/components/schemas/A"},
-            {"$ref": "#/components/schemas/B"},
-        ],
-        discriminator={
-            "propertyName": "type",
-            "mapping": {"a": "#/components/schemas/A", "b": "#/components/schemas/B"},
-        },
-        full_spec={},
-        realized_types={"A": A, "B": B},
-    )
-    data = {"type": "a"}
-    result = union.deserialize(data)
-    assert isinstance(result, A)
-
-
-def test_tagged_union_deserialize_use_python_names():
-    @dataclasses.dataclass
-    class A(BaseDto):
-        value: int
-        label: str = "default"
-
-    @dataclasses.dataclass
-    class B(BaseDto):
-        pass
-
-    A.name_map = {"value": "Value", "label": "Label"}
-    B.name_map = {}
-
-    union = TaggedUnion(
-        type_options=[
-            {"$ref": "#/components/schemas/A"},
-            {"$ref": "#/components/schemas/B"},
-        ],
-        discriminator={
-            "propertyName": "type",
-            "mapping": {"a": "#/components/schemas/A", "b": "#/components/schemas/B"},
-        },
-        full_spec={},
-        realized_types={"A": A, "B": B},
-    )
-
-    # With use_python_names=True, keys should be lowercase
-    data = {"type": "a", "value": 42, "label": "test"}
-    result = union.deserialize(data, use_python_names=True)
-    assert isinstance(result, A)
-    assert result.value == 42
-    assert result.label == "test"
-
-    # Without use_python_names, keys should be uppercase
-    data = {"type": "a", "Value": 42, "Label": "test"}
-    result = union.deserialize(data, use_python_names=False)
-    assert isinstance(result, A)
-    assert result.value == 42
-    assert result.label == "test"
 
 
 # --- TODO: Tests to implement ---


### PR DESCRIPTION
fast follow to #5 -- I didn't catch all the instances of `deserialize` and got this error when trying to implement:

```
TypeError: TaggedUnion.deserialize() got an unexpected keyword argument 'use_python_names'
```